### PR TITLE
Flags: inline id_ vars to fix "Constant expression expected" errors on Haxe 3.3.0

### DIFF
--- a/cx-src/zpp_nape/util/Flags.cx
+++ b/cx-src/zpp_nape/util/Flags.cx
@@ -86,7 +86,7 @@ class PR(Flags) {
     public static var internal:Bool = false;
 
     $(expand global FlagsInitID(N,F,I)
-        public static var id_`F`_`N = I;
+        public static force_inline var id_`F`_`N = I;
     );
     $(expand global FlagsInit(N,F,I)
         public static var F`_`N:F;


### PR DESCRIPTION
closes #100

Tested locally with caxe, the diff looks good:

![](http://i.imgur.com/USOYBgb.png)
