### PR TITLE
Added PixiJS ShapeDebug

### DIFF
--- a/buildlib
+++ b/buildlib
@@ -19,6 +19,6 @@ cat > haxelib.json << EOT
 EOT
 rm -f napelib.zip
 zip -r napelib .
-haxelib local napelib.zip
+haxelib install napelib.zip "nape" "local" --always
 cd ../
 

--- a/cx-src/nape/util/Debug.cx
+++ b/cx-src/nape/util/Debug.cx
@@ -101,7 +101,7 @@ class Debug {
         static public var BROADTOTAL = 0;
     #end
 
-    #if (flash9||openfl||nme)
+    #if (flash9||openfl||nme||pixi)
 
     !!/**
     !! * Create a flash/openfl||nme Shape representing the given Body.
@@ -110,10 +110,16 @@ class Debug {
     !! * @return A flash/openfl||nme.display.Shape representing Body.
     !! * @throws # If body is null.
     !! */
-    keep public static function createGraphic(body:Body):flash.display.Shape {
+    keep public static function createGraphic(body:Body):#if !pixi flash.display.Shape #else pixi.core.graphics.Graphics #end {
         DEBUG(if(body==null) throw "Error: Cannot create debug graphic for null Body";)
-        var ret = new flash.display.Shape();
-        var graphics = ret.graphics;
+        #if pixi
+        var graphics = new pixi.core.graphics.Graphics();
+        graphics.interactive = false;
+        graphics.interactiveChildren = false;
+        #else
+        var ret=new flash.display.Shape();
+        var graphics=ret.graphics;
+        #end
 
         var idc:Int = fastint(0xffffff*Math.exp(-body.id/1500));
         var _r = (((idc&0xff0000)>>16))*0.7;
@@ -145,7 +151,7 @@ class Debug {
             }
         }
 
-        return ret;
+        return #if pixi graphics #else ret #end;
     }
 
     !!/**
@@ -261,11 +267,13 @@ class Debug {
         colour = null;
     }
 
+
     !!/**
     !! * The flash/openfl||nme native display object representing debug draw.
     !! * <br/><br/>
     !! * When using debug drawer, you should add this to your display list.
     !! */
+    #if !pixi
     property(display, flash.display.DisplayObject, {
         #if flash10
             var ret:flash.display.DisplayObject;
@@ -276,6 +284,11 @@ class Debug {
             return pr(inner).d_shape.shape;
         #end
     })
+    #else
+    property(display, pixi.core.graphics.Graphics, {
+            return pr(inner).d_shape.graphics;
+        })
+    #end
 
     !!/**
     !! * When true, objects outside the debug draw screen will not be drawn.

--- a/cx-src/nape/util/Debug.cx
+++ b/cx-src/nape/util/Debug.cx
@@ -104,10 +104,10 @@ class Debug {
     #if (flash9||openfl||nme||pixi)
 
     !!/**
-    !! * Create a flash/openfl||nme Shape representing the given Body.
+    !! * Create a flash/openfl||nme||pixi Shape/Graphics representing the given Body.
     !! *
-    !! * @param body The body to create display Shape for.
-    !! * @return A flash/openfl||nme.display.Shape representing Body.
+    !! * @param body The body to create display Shape/Graphics for.
+    !! * @return A flash/openfl||nme.display.Shape||pixi.core.graphics.Graphics representing Body.
     !! * @throws # If body is null.
     !! */
     keep public static function createGraphic(body:Body):#if !pixi flash.display.Shape #else pixi.core.graphics.Graphics #end {
@@ -267,7 +267,7 @@ class Debug {
 
 
     !!/**
-    !! * The flash/openfl||nme native display object representing debug draw.
+    !! * The flash/openfl||nme||pixi native display object representing debug draw.
     !! * <br/><br/>
     !! * When using debug drawer, you should add this to your display list.
     !! */

--- a/cx-src/nape/util/Debug.cx
+++ b/cx-src/nape/util/Debug.cx
@@ -114,8 +114,6 @@ class Debug {
         DEBUG(if(body==null) throw "Error: Cannot create debug graphic for null Body";)
         #if pixi
         var graphics = new pixi.core.graphics.Graphics();
-        graphics.interactive = false;
-        graphics.interactiveChildren = false;
         #else
         var ret=new flash.display.Shape();
         var graphics=ret.graphics;

--- a/cx-src/nape/util/ShapeDebug.cx
+++ b/cx-src/nape/util/ShapeDebug.cx
@@ -4,7 +4,7 @@ $(import);
 #if (flash9||openfl||nme||pixi)
 
 !!/**
-!! * Implementation of nape debug draw using flash/openfl||nme graphics API.
+!! * Implementation of nape debug draw using flash/openfl||nme||pixi graphics API.
 !! * <br/><br/>
 !! * This debug draw is slower than BitmapDebug which is available in flash10+
 !! * however the BitmapDebug draw makes use of Alchemy opcodes so you may wish
@@ -19,7 +19,7 @@ $(import);
 
     !!/**
     !! * Thickness to draw lines with.
-    !! * @default 0.1
+    !! * @default 0.1 //pixi defaults to 1.0
     !! */
     public var thickness:Float = 0.0;
 

--- a/cx-src/nape/util/ShapeDebug.cx
+++ b/cx-src/nape/util/ShapeDebug.cx
@@ -1,7 +1,7 @@
 package nape.util;
 $(import);
 
-#if (flash9||openfl||nme)
+#if (flash9||openfl||nme||pixi)
 
 !!/**
 !! * Implementation of nape debug draw using flash/openfl||nme graphics API.
@@ -51,7 +51,7 @@ $(import);
         pr(inner).outer = this;
 
         this.bgColour = bgColour;
-        this.thickness = 0.1;
+        this.thickness = #if !pixi 0.1 #else 1 #end;
     }
 
     !!/**
@@ -107,7 +107,11 @@ $(import);
         g.lineStyle(thickness,colour&0xffffff,1);
         if(pr(inner).xnull) {
             g.moveTo(start.x,start.y);
+            #if pixi
+            g.quadraticCurveTo(control.x,control.y,end.x,end.y);
+            #else
             g.curveTo(control.x,control.y,end.x,end.y);
+            #end
 
             WEAK(start);
             WEAK(control);
@@ -117,7 +121,11 @@ $(import);
             var v = pr(inner).xform.outer.transform(control);
             var q = pr(inner).xform.outer.transform(end);
             g.moveTo(u.x,u.y);
+            #if pixi
+            g.quadraticCurveTo(v.x,v.y,q.x,q.y);
+            #else
             g.curveTo(v.x,v.y,q.x,q.y);
+            #end
             u.dispose();
             v.dispose();
             q.dispose();

--- a/cx-src/zpp_nape/constraint/AngleJoint.cx
+++ b/cx-src/zpp_nape/constraint/AngleJoint.cx
@@ -223,7 +223,7 @@ class PR(AngleJoint) extends PR(Constraint) {
     }
 
     public override function draw(g:Debug) {
-    #if (flash9||openfl||nme)
+    #if (flash9||openfl||nme||pixi)
         var me = outer_zn;
 
         var minrad = 10;
@@ -263,7 +263,7 @@ class PR(AngleJoint) extends PR(Constraint) {
 
 )
 
-#if (flash9||openfl||nme)
+#if (flash9||openfl||nme||pixi)
 class PR(AngleDraw) {
     public static function indicator(g:Debug, c:Vec2, ang:Float, rad:Float, col:Int) {
         var dir = Vec2.get(Math.cos(ang),Math.sin(ang));

--- a/cx-src/zpp_nape/constraint/DistanceJoint.cx
+++ b/cx-src/zpp_nape/constraint/DistanceJoint.cx
@@ -269,7 +269,7 @@ class PR(DistanceJoint) extends PR(Constraint) {
     //----------------------------------------------
 
     public override function draw(g:Debug) {
-    #if (flash9||openfl||nme)
+    #if (flash9||openfl||nme||pixi)
         var me = outer_zn;
         var a1 = me.body1.localPointToWorld(me.anchor1);
         var a2 = me.body2.localPointToWorld(me.anchor2);

--- a/cx-src/zpp_nape/constraint/LineJoint.cx
+++ b/cx-src/zpp_nape/constraint/LineJoint.cx
@@ -282,7 +282,7 @@ class PR(LineJoint) extends PR(Constraint) {
     //----------------------------------------------
 
     public override function draw(g:Debug) {
-    #if (flash9||openfl||nme)
+    #if (flash9||openfl||nme||pixi)
         var me = outer_zn;
         var a1 = me.body1.localPointToWorld(me.anchor1);
         var a2 = me.body2.localPointToWorld(me.anchor2);

--- a/cx-src/zpp_nape/constraint/PivotJoint.cx
+++ b/cx-src/zpp_nape/constraint/PivotJoint.cx
@@ -223,7 +223,7 @@ class PR(PivotJoint) extends PR(Constraint) {
     //----------------------------------------------
 
     public override function draw(g:Debug) {
-    #if (flash9||openfl||nme)
+    #if (flash9||openfl||nme||pixi)
         var me = outer_zn;
         var a1 = me.body1.localPointToWorld(me.anchor1);
         var a2 = me.body2.localPointToWorld(me.anchor2);

--- a/cx-src/zpp_nape/constraint/PulleyJoint.cx
+++ b/cx-src/zpp_nape/constraint/PulleyJoint.cx
@@ -355,7 +355,7 @@ class PR(PulleyJoint) extends PR(Constraint) {
     //----------------------------------------------
 
     public override function draw(g:Debug) {
-    #if (flash9||openfl||nme)
+    #if (flash9||openfl||nme||pixi)
         var me = outer_zn;
         var a1 = me.body1.localPointToWorld(me.anchor1);
         var a2 = me.body2.localPointToWorld(me.anchor2);
@@ -384,7 +384,7 @@ class PR(PulleyJoint) extends PR(Constraint) {
     #end
     }
 
-    #if (flash9||openfl||nme)
+    #if (flash9||openfl||nme||pixi)
     public function drawLink(g:Debug, a1:Vec2, a2:Vec2, n:Vec2, nl:Float, bias:Float, scale:Float, ca:Int, cb:Int) {
         if (nl != 0) {
             n.muleq(1 / nl);

--- a/cx-src/zpp_nape/constraint/WeldJoint.cx
+++ b/cx-src/zpp_nape/constraint/WeldJoint.cx
@@ -238,7 +238,7 @@ class PR(WeldJoint) extends PR(Constraint) {
     //----------------------------------------------
 
     public override function draw(g:Debug) {
-    #if (flash9||openfl||nme)
+    #if (flash9||openfl||nme||pixi)
         var me = outer_zn;
         var a1 = me.body1.localPointToWorld(me.anchor1);
         var a2 = me.body2.localPointToWorld(me.anchor2);

--- a/cx-src/zpp_nape/util/Debug.cx
+++ b/cx-src/zpp_nape/util/Debug.cx
@@ -133,8 +133,6 @@ class PR(ShapeDebug) extends PR(Debug) {
         graphics = shape.graphics;
         #else
         graphics = new pixi.core.graphics.Graphics();
-        graphics.interactive = false;
-        graphics.interactiveChildren = false;
         #end
 
         isbmp = false;

--- a/cx-src/zpp_nape/util/Debug.cx
+++ b/cx-src/zpp_nape/util/Debug.cx
@@ -6,7 +6,7 @@ $(import);
     $(mixin mat_xform_hom(Anull,A,u) if(!Anull) mat_transform_hom(A.,u));
     $(mixin mat_xform    (Anull,A,u) if(!Anull) mat_transform    (A.,u));
 
-#if (flash9||openfl||nme)
+#if (flash9||openfl||nme||pixi)
 
 class PR(Debug) {
     public static var internal = false;
@@ -121,14 +121,21 @@ class PR(Debug) {
 class PR(ShapeDebug) extends PR(Debug) {
     public var outer_zn:ShapeDebug = null;
 
-    public var shape:flash.display.Shape = null;
-    public var graphics:flash.display.Graphics = null;
+    #if !pixi public var shape:flash.display.Shape = null; #end
+    public var graphics:#if !pixi flash.display.Graphics #else pixi.core.graphics.Graphics #end = null;
 
     public function new(width:Int,height:Int) {
         super(width,height);
+
+        #if !pixi
         shape = new flash.display.Shape();
         shape.scrollRect = new flash.geom.Rectangle(0,0,width,height);
         graphics = shape.graphics;
+        #else
+        graphics = new pixi.core.graphics.Graphics();
+        graphics.interactive = false;
+        graphics.interactiveChildren = false;
+        #end
 
         isbmp = false;
         d_shape = this;


### PR DESCRIPTION
This was fairly straightforward to add. The only difference between OpenFL/Flash API was `curveTo` => `quadraticCurveTo`. Then, for some reason, pixi refuses to draw sub pixel line thickness, so I've set the default thickness for pixi to `1`. All and all, everything seems to be working perfectly.

Also, `haxelib local` is being deprecated, I've changed this to `haxelib install` pointing to the zip.