### PR TITLE
Update property declaration syntax for Haxe 4 compatibility

### DIFF
--- a/cx-src/nape/callbacks/CbType.cx
+++ b/cx-src/nape/callbacks/CbType.cx
@@ -38,7 +38,7 @@ $(import);
         $doc($$*$$desc)
         !! * In a Listener (Assuming you do not 'remove' this type from the object)
         !! */
-        #if nape_swc @:isVar #end public static var ANY_`T(get_ANY_`T, never):CbType;
+        #if nape_swc @:isVar #end public static var ANY_`T(get, never):CbType;
         force_inline static function get_ANY_`T():CbType {
             return PR(CbType).ANY_`T;
         }

--- a/cx-src/zpp_nape/util/Flags.cx
+++ b/cx-src/zpp_nape/util/Flags.cx
@@ -58,7 +58,7 @@ $(mixin global Flags(F,defs)
         FlagsInit(N,F,I)
         tostring(N)
 
-        #if nape_swc @:isVar #end public static var N(get_`N,never):F;
+        #if nape_swc @:isVar #end public static var N(get,never):F;
         force_inline static function get_`N() {
             if(PR(Flags).F`_`N==null) {
                 PR(Flags).internal = true;

--- a/cx-src/zpp_nape/util/Names.cx
+++ b/cx-src/zpp_nape/util/Names.cx
@@ -89,7 +89,7 @@ $(mixin global newTArray(T) {
 });
 
 $(mixin global property(name,Type,getter,setter)
-    #if nape_swc @:isVar #end public var $name(get_`name,set_`name):Type;
+    #if nape_swc @:isVar #end public var $name(get,set):Type;
     force_inline function get_`name():Type getter
     force_inline function set_`name(name:Type):Type {
         setter
@@ -98,6 +98,6 @@ $(mixin global property(name,Type,getter,setter)
 );
 
 $(mixin global property(name,Type,getter)
-    #if nape_swc @:isVar #end public var $name(get_`name,never):Type;
+    #if nape_swc @:isVar #end public var $name(get,never):Type;
     force_inline function get_`name():Type getter
 );

--- a/cx-src/zpp_nape/util/WrapLists.cx
+++ b/cx-src/zpp_nape/util/WrapLists.cx
@@ -122,7 +122,7 @@ $(mixin global WrapListNew(T,ListT,IteT, defs, noFinal)
         !!/**
         !! * Length of list.
         !! */
-        #if nape_swc @:isVar #end public var length(get_length,never):Int;
+        #if nape_swc @:isVar #end public var length(get,never):Int;
         //this must truly be inlined for nape_swc.
         #if use_inline
             force_inline function get_length() {


### PR DESCRIPTION
see HaxeFoundation/haxe#4699 - Haxe 4 removes support for the old Haxe 2 style property syntax, so trying to compile Nape with it leads to a bunch of errors:

```
C:/HaxeToolkit/haxe/lib/nape/2,0,20/nape/geom/Vec2.hx:641: characters 2-50 : length: Custom property accessor is no longer supported, please use set
C:/HaxeToolkit/haxe/lib/nape/2,0,20/nape/geom/Vec2.hx:921: characters 2-47 : angle: Custom property accessor is no longer supported, please use get
C:/HaxeToolkit/haxe/lib/nape/2,0,20/nape/geom/Vec2.hx:921: characters 2-47 : angle: Custom property accessor is no longer supported, please use set
C:/HaxeToolkit/haxe/lib/nape/2,0,20/nape/dynamics/ArbiterList.hx:248: characters 2-43 : length: Custom property accessor is no longer supported, please use get
C:/HaxeToolkit/haxe/lib/nape/2,0,20/nape/geom/Vec2List.hx:248: characters 2-43 : length: Custom property accessor is no longer supported, please use get
C:/HaxeToolkit/haxe/lib/nape/2,0,20/nape/constraint/Constraint.hx:197: characters 2-60 : userData: Custom property accessor is no longer supported, please use get
C:/HaxeToolkit/haxe/lib/nape/2,0,20/nape/constraint/Constraint.hx:224: characters 2-65 : compound: Custom property accessor is no longer supported, please use get
```

@deltaluca If you want to make a release right away, here's a .zip with an updated `haxelib.json` and rebuilt sources: [2,0,21.zip](https://github.com/deltaluca/nape/files/2364240/2.0.21.zip)
 